### PR TITLE
chore(workflows): correct download-grype version comments

### DIFF
--- a/.github/workflows/chainctl-image-diff.yaml
+++ b/.github/workflows/chainctl-image-diff.yaml
@@ -50,7 +50,7 @@ jobs:
         identity: "326bcde5903252f3ae2fe01c691b5a50f7046b5d/10275f9d35604b8e"
 
     # Install grype. It's required by chainctl image diff.
-    - uses: anchore/scan-action/download-grype@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v6.1.0
+    - uses: anchore/scan-action/download-grype@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
       id: download_grype
 
     # Install cosign. We'll use this to verify image signatures.

--- a/.github/workflows/grype-scan.yaml
+++ b/.github/workflows/grype-scan.yaml
@@ -28,7 +28,7 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     # Install grype
-    - uses: anchore/scan-action/download-grype@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v6.1.0
+    - uses: anchore/scan-action/download-grype@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
       id: download_grype
 
     # Run digestabot


### PR DESCRIPTION
Based on running `pinact run --update`